### PR TITLE
Support to optinally install the debug_info files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ All essential modules of Qt are downloaded by default. Installation of a require
 essential modules is supported as well. See option `--module`.
 
 Add-on modules are not downloaded by default. One has to list desired add-ons explicitly by
-means of the option `--addon`.
+means of the option `--addon`. On Windows, adding `debug_info` to the list of addons installs
+the debug files for the essential modules as well as the selected addons.
 
 Mirrors of official servers are supported by the option `--server`.
 

--- a/qt-downloader
+++ b/qt-downloader
@@ -176,7 +176,7 @@ def build_tool_url(args, name):
   return base_url(args.server) + '{}/{}/tools_{}/'.format(OsMap[args.os], args.target, name)
 
  
-def get_modules_info(url, version, toolchain):
+def get_modules_info(url, version, toolchain, with_debug_files=False):
   reply = requests.get(url + "Updates.xml")
   if reply.status_code != requests.codes.ok:
     print(reply.content, file=sys.stderr)
@@ -202,7 +202,7 @@ def get_modules_info(url, version, toolchain):
     archives = package.xpath('DownloadableArchives/text()')[0].split(', ')
     if len(name_parts) == 4:
       info['main'] = (name, version, archives)
-    elif len(name_parts) == 5 and name_parts[3] != 'debug_info':
+    elif len(name_parts) == 5 and (with_debug_files or name_parts[3] != 'debug_info'):
       info['addons'].append((name, version, archives))
 
   if info['main'] is None:
@@ -480,7 +480,15 @@ def accept_opensource_license(args):
   qconfig_pri.write_text(contents_licheck)
   print('Done')
     
-    
+
+def get_debug_modules_list(main_archives, addons):
+  modules = []
+  for archive in main_archives:
+    modules.append(archive.split('-')[0])
+  modules.extend(addons)
+  return modules
+
+
 def main():
   parser = argparse.ArgumentParser(description='Qt downloader',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -512,7 +520,7 @@ def main():
     verify_parameters(args)
     url = build_main_url(args)
 
-    info = get_modules_info(url, args.version, args.toolchain)
+    info = get_modules_info(url, args.version, args.toolchain, "debug_info" in args.addons)
     if info is None or info['main'] is None:
       sys.exit(1)
 
@@ -525,8 +533,14 @@ def main():
     if len(args.addons) > 0:
       for name, version, archives in info['addons']:
         addon_name = name.split('.')[3]
+        print("Addon: ", addon_name)
         if addon_name in args.addons:
-          download_and_extract(addon_name, url + name + '/' + version, archives, None, args.output)
+          modules = None
+          if addon_name == "debug_info":
+            # install base modules plus any given in args.addons
+            _, _, main_archives = info['main']
+            modules = get_debug_modules_list(main_archives, args.addons)
+          download_and_extract(addon_name, url + name + '/' + version, archives, modules, args.output)
 
     if args.openssl:
       ossl_distribution = discover_openssl_tool(args, 'openssl')

--- a/qt-downloader
+++ b/qt-downloader
@@ -196,6 +196,7 @@ def get_modules_info(url, version, toolchain, with_debug_files=False):
     name = package.xpath('Name/text()')[0]
     name_parts = name.split('.')
     if name_parts[0:3] != ['qt', 'qt{}'.format(major), ver] or name_parts[-1] != toolchain:
+      # print(name, "-> ignored", name_parts[0:3], name_parts[-1])
       continue
 
     version = package.xpath('Version/text()')[0]
@@ -204,6 +205,11 @@ def get_modules_info(url, version, toolchain, with_debug_files=False):
       info['main'] = (name, version, archives)
     elif len(name_parts) == 5 and (with_debug_files or name_parts[3] != 'debug_info'):
       info['addons'].append((name, version, archives))
+    elif len(name_parts) == 6:
+      info['addons'].append((name, version, archives))
+    else:
+      # print(name, "-> ignored", name_parts)
+      pass
 
   if info['main'] is None:
     print('Update.xml does not contain proper entry for Qt kit', file=sys.stderr)
@@ -533,7 +539,9 @@ def main():
     if len(args.addons) > 0:
       for name, version, archives in info['addons']:
         addon_name = name.split('.')[3]
-        print("Addon: ", addon_name)
+        if addon_name == "addons":
+          addon_name = name.split('.')[4]
+        # print(addon_name, args.addons)
         if addon_name in args.addons:
           modules = None
           if addon_name == "debug_info":


### PR DESCRIPTION
This PR adds the ability to install the Windows debugging archives containing the PDB files. Just add `debug_info` to the list of addons to install.